### PR TITLE
Append to import/plugin path instead of replacing

### DIFF
--- a/src/commandline/commandlineparser.cpp
+++ b/src/commandline/commandlineparser.cpp
@@ -43,6 +43,17 @@ CommandLineParser::CommandLineParser(int argc, char *argv[])
     }
 };
 
+void CommandLineParser::setEngine(QQmlEngine* engine)
+{
+    for (const auto path : _importPaths) {
+        engine->addImportPath(path);
+    }
+
+    for (const auto path : _pluginPaths) {
+        engine->addPluginPath(path);
+    }
+}
+
 void CommandLineParser::printHelp()
 {
     for (const auto& optionStruct : _optionsStruct) {

--- a/src/commandline/commandlineparser.h
+++ b/src/commandline/commandlineparser.h
@@ -33,11 +33,7 @@ public:
      *
      * @param qmlengine
      */
-    void setEngine(QQmlEngine* engine)
-    {
-        engine->setImportPathList(_importPaths);
-        engine->setPluginPathList(_pluginPaths);
-    }
+    void setEngine(QQmlEngine* engine);
 
     /**
      * @brief Set the QCoreApplication to do the necessary configuration


### PR DESCRIPTION
This keeps the default QML import path which contains the directory of the application executable, paths specified in the `QML2_IMPORT_PATH` environment variable, and the builtin Qml2ImportsPath from `QLibraryInfo`.

It also eliminates the need for importing not needed modules in the main qml file.

Fixes #12 