### PR TITLE
Add support for loading a profile

### DIFF
--- a/src/commandline/commandlineparser.h
+++ b/src/commandline/commandlineparser.h
@@ -62,6 +62,8 @@ private:
     QList<std::function<void()>> _posAppFunctions;
 
     void printHelp();
+    void _parseQHotProfile(QStringView profilePath);
+    void _translate(const QString& translationFile);
 
     QStringList _importPaths;
     QStringList _pluginPaths;
@@ -107,17 +109,11 @@ private:
         },
         {
             {"translation", "Set the translation file (file)", "file"},
-            [this](const QString& argument) {
-                if(!_translator.load(argument)) {
-                    qDebug() << "Failed to load translation file:" << argument;
-                    return;
-                }
-
-#if QT_VERSION > QT_VERSION_CHECK(5, 15, 0)
-                qDebug() << "Translation loaded successfully, language:" << _translator.language();
-                qDebug() << _translator.translate(nullptr, "car");
-#endif
-            },
+            [this](const QString& argument) { _translate(argument); },
+        },
+        {
+            {"profile-path", "Add path to qhot_profile.json file", "file"},
+            [this](const QString& argument) { _parseQHotProfile(argument); },
         },
     };
 };


### PR DESCRIPTION
I implemented an extra command ```--profile-path```, that will parse a json file called ```qhot-profile.json```. This file can store exactly the same options as on the command line. 

For example:

```json
{
   "import-path":[
      "lib/modules",
      "app/src/qml"
   ],
   "style":"material"
}
```

The import and plugin paths can be either absolute or relative to the path of qhot-profile.json.

This makes it for example possible to use qhot as an external tool in QtCreator. In QtCreator qhot can be configured to look for qhot-profile.json in the project root and load the current *.qml document. That way you a live viewer directly integrated in the IDE.