### PR TITLE
Qt6: port to Qt6 - C++ part

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,15 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-find_package(Qt5 REQUIRED
+option(QHOT_USE_QT6 "Use Qt6" OFF)
+
+if(QHOT_USE_QT6)
+    set(QT_VERSION Qt6)
+else()
+    set(QT_VERSION Qt5)
+endif()
+
+find_package(${QT_VERSION} REQUIRED
     Core
     Gui
     Qml

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -1,12 +1,16 @@
 import QtQuick 2.12
 import QtQuick.Controls 2.3
 import QtQuick.Controls.Material 2.1
-import QtQuick.Dialogs 1.3
 import QtQuick.Layouts 1.3
+
+// Qt6! Use 'Qt.labs.platform' instead of 'QtQuick.Dialogs'
+//import Qt.labs.platform 1.0
+import QtQuick.Dialogs 1.3
 
 import QtCharts 2.3
 
-import QtGraphicalEffects 1.0
+// Qt6! Use Qt5Compat.GraphicalEffects
+// import QtGraphicalEffects 1.0
 
 import QtQml.Models 2.2
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,7 +3,11 @@ set(CMAKE_AUTOMOC ON)
 # Automatically link Qt executables to qtmain target on Windows
 cmake_policy(SET CMP0020 NEW)
 
-qt5_add_resources(RESOURCES ../resources.qrc)
+if(QHOT_USE_QT6)
+    qt6_add_resources(RESOURCES ../resources.qrc)
+else()
+    qt5_add_resources(RESOURCES ../resources.qrc)
+endif()
 
 add_executable(qhot
     main.cpp
@@ -21,13 +25,13 @@ target_include_directories(qhot
 )
 
 target_link_libraries(qhot
-    Qt5::Core
-    Qt5::Gui
-    Qt5::Qml
-    Qt5::QuickControls2
+    Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::Gui
+    Qt${QT_VERSION_MAJOR}::Qml
+    Qt${QT_VERSION_MAJOR}::QuickControls2
 )
 
-get_target_property(QT_MOC_EXECUTABLE Qt5::moc LOCATION)
+get_target_property(QT_MOC_EXECUTABLE Qt${QT_VERSION_MAJOR}::moc LOCATION)
 get_filename_component(QT_INSTALL_PREFIX ${QT_MOC_EXECUTABLE} DIRECTORY)
 if (EXISTS ${QT_INSTALL_PREFIX})
     install(

--- a/src/commandline/commandlineparser.cpp
+++ b/src/commandline/commandlineparser.cpp
@@ -134,9 +134,11 @@ void CommandLineParser::_parseQHotProfile(const QString& profilePath)
     if (software.toBool(), false)
         QCoreApplication::setAttribute(Qt::AA_UseSoftwareOpenGL);
 
+#if QT_VERSION_MAJOR < 6
     auto scaling = jsonObject.value(QLatin1String{"scaling"});
     if (scaling.toBool(), false)
         QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+#endif
 
     auto importPaths = jsonObject.value(QLatin1String{"import-path"});
     if (importPaths.isArray()) {

--- a/src/commandline/commandlineparser.h
+++ b/src/commandline/commandlineparser.h
@@ -84,6 +84,7 @@ private:
             {"software", "Force use of software rendering (Qt::AA_UseSoftwareOpenGL)"},
             [](const QString&) { QCoreApplication::setAttribute(Qt::AA_UseSoftwareOpenGL); },
         },
+#if QT_VERSION_MAJOR < 6
         {
             {"scaling", "Enable High DPI scaling (AA_EnableHighDpiScaling)"},
             [](const QString&) { QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling); },
@@ -92,6 +93,7 @@ private:
             {"no-scaling", "Disable High DPI scaling (AA_DisableHighDpiScaling)"},
             [](const QString&) { QCoreApplication::setAttribute(Qt::AA_DisableHighDpiScaling); },
         },
+#endif
         {
             {{"import-path", "I"}, "Add list of **import** paths (path:path)", "paths"},
             [this](const QString& argument) { _importPaths = argument.split(':'); },


### PR DESCRIPTION
This PR tries to port QHot to Qt6, with:

**Limitations:**

- `QtQuick.Dialog :: FileDialog` has been moved to [`Qt.labs.platform`](https://doc-snapshots.qt.io/qt6-dev/qml-qt-labs-platform-filedialog.html) (Available since Qt 5.8) 
  - `fileUrl` property is now named `file`
  - (*move it now?*)
- `QtGraphicalEffects` is removed, may need `Qt5Compat` to import it back 
  - (*is this import really in use?*)

**Changes:**

Added a CMake option `QHOT_USE_QT6` which defaults to `OFF`
Used `${QT_VERSION_MAJOR}` in CMake `target_link_libraries` and `get_target_property` which will be set to 5 or 6 accordingly.
Removed command line option `scaling` and `no-scaling` since HiDPI scales are always enabled in Qt6.
- Codes related to the limitations above are not changed (may be we cannot support both 5 and 6 ATST)