### PR TITLE
Allow specifying the application name in configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ To run qhot:
 --profile-path           Path (including filename) to qhot-profile.json (file)
 --background             Set the background color (color)
 --quick-controls-conf    Path (including filename) to qtquickcontrols2.conf (file)
+--app-name               Name of the application running inside qhot (name)
 ```
 
 ### Store options in a profile

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -13,7 +13,7 @@ import ProvidesSomething
 
 ApplicationWindow {
     id: window
-    title: "QHot"
+    title: Qt.application.name
     visible: true
 
     Shortcut {

--- a/src/commandline/commandlineparser.cpp
+++ b/src/commandline/commandlineparser.cpp
@@ -165,6 +165,14 @@ void CommandLineParser::_parseQHotProfile(const QString& profilePath)
         auto absPath = profileDir.absoluteFilePath(controlsConfPath.toString());
         qputenv("QT_QUICK_CONTROLS_CONF", absPath.toLocal8Bit());
     }
+
+    auto appName = jsonObject.value(QLatin1String { "app-name" });
+    if (appName.isString()) {
+        _posAppFunctions.append(
+            [appName]{
+                qApp->setApplicationName(APPNAME_FORMAT.arg(appName.toString()));
+        });
+    }
 }
 
 void CommandLineParser::_translate(const QString &translationFile)

--- a/src/commandline/commandlineparser.h
+++ b/src/commandline/commandlineparser.h
@@ -12,6 +12,8 @@
 
 #include "../providessomething.h"
 
+#define APPNAME_FORMAT QStringLiteral("qhot (%1)")
+
 /**
  * @brief Deal with command lines
  *
@@ -107,6 +109,10 @@ private:
         {
             {"quick-controls-conf", "Path (including filename) to qtquickcontrols2.conf", "file"},
             [](const QString& path) { qputenv("QT_QUICK_CONTROLS_CONF", path.toLocal8Bit()); },
+        },
+        {
+            {"app-name", "Name of the application to set in QGuiApplication::setApplicationName", "name"},
+            [this](const QString& argument) { _posAppFunctions.append([argument]{ qApp->setApplicationName(APPNAME_FORMAT.arg(argument)); });},
         },
     };
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,11 +12,11 @@ int main(int argc, char *argv[])
 {
     qmlRegisterSingletonType<ProvidesSomething>("ProvidesSomething", 1, 0, "ProvidesSomething", ProvidesSomething::qmlSingletonRegister);
 
-    CommandLineParser commandLineParser(argc, argv);
 
     QGuiApplication app(argc, argv);
     app.setOrganizationDomain("patrickelectric.work");
     app.setOrganizationName("patrickelectric");
+    CommandLineParser commandLineParser(argc, argv);
     commandLineParser.setApplication(&app);
 
     QQmlApplicationEngine appEngine(QUrl("qrc:/main.qml"));


### PR DESCRIPTION
This is useful for QSettings and possibly other things. I also put the name into the window title so it's easier to determine what's running in which window.