### PR TITLE
Traverse app and config parent directories when looking up modules

### DIFF
--- a/src/commandline/commandlineparser.cpp
+++ b/src/commandline/commandlineparser.cpp
@@ -8,6 +8,8 @@
 
 #include <utility>
 
+#define MAX_RECURSIVE_SEARCH_DEPTH 3
+
 CommandLineParser::CommandLineParser(int argc, char *argv[])
     : QCommandLineParser()
 {
@@ -138,7 +140,16 @@ void CommandLineParser::_parseQHotProfile(const QString& profilePath)
     if (importPaths.isArray()) {
         const auto paths = importPaths.toArray();
         for (const auto &path : paths) {
-            _importPaths.append(profileDir.absoluteFilePath(path.toString()));
+            auto potentialPath = _lookupDirectory(path.toString(), qApp->applicationDirPath(), MAX_RECURSIVE_SEARCH_DEPTH);
+            if (!potentialPath.isEmpty()) {
+                _importPaths.append(potentialPath);
+                continue;
+            }
+            potentialPath = _lookupDirectory(path.toString(), profilePath, MAX_RECURSIVE_SEARCH_DEPTH);
+            if (!potentialPath.isEmpty()) {
+                _importPaths.append(potentialPath);
+                continue;
+            }
         }
     }
 
@@ -146,7 +157,16 @@ void CommandLineParser::_parseQHotProfile(const QString& profilePath)
     if (pluginPaths.isArray()) {
         const auto paths = pluginPaths.toArray();
         for (const auto &path : paths) {
-            _pluginPaths.append(profileDir.absoluteFilePath(path.toString()));
+            auto potentialPath = _lookupDirectory(path.toString(), qApp->applicationDirPath(), MAX_RECURSIVE_SEARCH_DEPTH);
+            if (!potentialPath.isEmpty()) {
+                _pluginPaths.append(potentialPath);
+                continue;
+            }
+            potentialPath = _lookupDirectory(path.toString(), profilePath, MAX_RECURSIVE_SEARCH_DEPTH);
+            if (!potentialPath.isEmpty()) {
+                _pluginPaths.append(potentialPath);
+                continue;
+            }
         }
     }
 
@@ -179,4 +199,18 @@ void CommandLineParser::_translate(const QString &translationFile)
     qDebug() << _translator.translate(nullptr, "car");
 #endif
 
+}
+
+QString CommandLineParser::_lookupDirectory(const QString &needle, const QString &parentDirPath, int maximumDepth)
+{
+    QDir parentDir(parentDirPath);
+    QString parentPrefix = QStringLiteral("");
+    for (int i = 0; i < maximumDepth; i++) {
+        auto relativeToBinaryPath = parentDir.absoluteFilePath(parentPrefix + needle);
+        if (QDir(relativeToBinaryPath).exists()) {
+            return relativeToBinaryPath;
+        }
+        parentPrefix += QStringLiteral("../");
+    }
+    return {};
 }

--- a/src/commandline/commandlineparser.h
+++ b/src/commandline/commandlineparser.h
@@ -57,6 +57,7 @@ private:
     void printHelp();
     void _parseQHotProfile(const QString& profilePath);
     void _translate(const QString& translationFile);
+    static QString _lookupDirectory(const QString& needle, const QString& parentDirPath, int maximumDepth = 1);
 
     QStringList _importPaths;
     QStringList _pluginPaths;


### PR DESCRIPTION
When running something from the build folder, it was really hard to set up the paths properly and it would have to be done manually in most cases. Traversing up from the binary makes it a lot easier. It also takes preference over the config dir because there may be clashes between dir names and the ones in build dir should be preferred.

I'm not sure about the macro constant, not very idiomatic C++, I know.

I know qhot can be integrated in Qt Creator but this makes it way easier to integrate it into CMake and you get automatic setup 'for free', check out this commit in my project to see how I use it: https://github.com/LithApp/Lith/commit/1197bd487f8dd48eccfe5b4ac63b891244d1fe59 .

In case you want to discuss anything about the PRs I opened today, feel free to hit me on m@rtinbriza.cz or ping Bizon on libera.chat. Thanks for this awesome tool, it will make my life a lot easier!