### PR TITLE
Fix QtCharts segfaulting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(Qt6 REQUIRED
     Qml
     Quick
     QuickControls2
+    Widgets
 )
 qt_standard_project_setup()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,6 +25,7 @@ target_link_libraries(qhot
     Qt6::Gui
     Qt6::Qml
     Qt6::QuickControls2
+    Qt6::Widgets
 )
 
 get_target_property(QT_MOC_EXECUTABLE Qt6::moc IMPORTED_LOCATION)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,10 +2,10 @@
 #include "providessomething.h"
 #include "urlinterceptor.h"
 
+#include <QApplication>
 #include <QtCore/QDebug>
 #include <QtCore/QDir>
 #include <QtCore/QFile>
-#include <QtGui/QGuiApplication>
 #include <QtQml/QQmlApplicationEngine>
 
 int main(int argc, char *argv[])
@@ -13,7 +13,7 @@ int main(int argc, char *argv[])
     qmlRegisterSingletonType<ProvidesSomething>("ProvidesSomething", 1, 0, "ProvidesSomething", ProvidesSomething::qmlSingletonRegister);
 
 
-    QGuiApplication app(argc, argv);
+    QApplication app(argc, argv);
     app.setOrganizationDomain("patrickelectric.work");
     app.setOrganizationName("patrickelectric");
     CommandLineParser commandLineParser(argc, argv);


### PR DESCRIPTION
QtCharts seems to be using QWidget internally. Add Widgets as a dependency and initialize using QApplication.

Fixes #19 